### PR TITLE
Reverse sort order for help requests (now descending by time)

### DIFF
--- a/src/HelperQueue/HelperView/HelperView.jsx
+++ b/src/HelperQueue/HelperView/HelperView.jsx
@@ -43,13 +43,7 @@
                     };
 
                     var updatedMoreRecently = function(a, b) {
-                        if (a.updated_at < b.updated_at) {
-                            return 1;
-                        } else if (b.updated_at < a.updated_at) {
-                            return -1;
-                        } else {
-                            return 0;
-                        }
+                        return moment(a.created_at).isBefore(b.created_at) ? 1 : -1;
                     };
 
                     var requests = {

--- a/src/HelperQueue/HelperView/HelperView.jsx
+++ b/src/HelperQueue/HelperView/HelperView.jsx
@@ -42,10 +42,20 @@
                         return !("helper" in r);
                     };
 
+                    var updatedMoreRecently = function(a, b) {
+                        if (a.updated_at < b.updated_at) {
+                            return 1;
+                        } else if (b.updated_at < a.updated_at) {
+                            return -1;
+                        } else {
+                            return 0;
+                        }
+                    };
+
                     var requests = {
                         unassigned: _.filter(open, isUnassigned),
-                        assigned: _.reject(open, isUnassigned),
-                        closed_recently: closed_recently
+                        assigned: _.reject(open, isUnassigned).sort(updatedMoreRecently),
+                        closed_recently: closed_recently.sort(updatedMoreRecently)
                     };
 
                     this.setState({requests: requests});


### PR DESCRIPTION
Most people who look at the list of currently assigned help requests are double checking the name or location of a student they JUST signed up to help.  We should sort open help requests (and recently closed) so that the most recently modified help requests are shown first.